### PR TITLE
Add the option prettier.onlyUseLocalVersion to force the usage of the local version of prettier (ignoring the bundled version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules

--- a/Readme.md
+++ b/Readme.md
@@ -161,6 +161,10 @@ _Note: Disabling a language enabled in a parent folder will prevent formatting i
 
 Text of status item indicating current buffer can't be formatted by prettier.
 
+#### prettier.onlyUseLocalVersion (default: false)
+
+Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier
+
 ## Prettier resolution
 
 This extension will use prettier from your project's local dependencies. Should prettier not be installed locally with your project's dependencies, a copy will be bundled with the extension.

--- a/package.json
+++ b/package.json
@@ -184,6 +184,12 @@
           "default": "avoid",
           "description": "Include parentheses around a sole arrow function parameter",
           "scope": "resource"
+        },
+        "prettier.onlyUseLocalVersion": {
+          "type": "boolean",
+          "default": false,
+          "description": "Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier",
+          "scope": "resource"
         }
       }
     },
@@ -208,6 +214,7 @@
     "@chemzqm/tsconfig": "^0.0.3",
     "@chemzqm/tslint-config": "^1.0.18",
     "@types/node": "^12.0.2",
+    "@types/read-pkg-up": "^3.0.1",
     "@types/semver": "^6.0.1",
     "coc.nvim": "^0.0.67",
     "ignore": "^5.1.1",
@@ -226,6 +233,7 @@
     "prettier": "^1.17.1",
     "prettier-eslint": "^8.8.2",
     "prettier-stylelint": "^0.4.2",
-    "prettier-tslint": "^0.4.2"
+    "prettier-tslint": "^0.4.2",
+    "read-pkg-up": "^6.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
-import { ExtensionContext, events, workspace, languages, commands } from 'coc.nvim'
+import { ExtensionContext, events, workspace, languages, commands, Uri } from 'coc.nvim'
 import { Disposable, DocumentSelector, TextEdit } from 'vscode-languageserver-protocol'
 import configFileListener from './configCacheHandler'
 import { setupErrorHandler } from './errorHandler'
 import ignoreFileHandler from './ignoreFileHandler'
 import EditProvider, { format, fullDocumentRange } from './PrettierEditProvider'
-import { allLanguages, rangeLanguages, enabledLanguages } from './utils'
+import { allLanguages, rangeLanguages, enabledLanguages, getConfig, hasLocalPrettierInstalled } from './utils'
+import { PrettierVSCodeConfig } from './types';
 
 interface Selectors {
   rangeLanguageSelector: DocumentSelector
@@ -53,15 +54,18 @@ function wait(ms: number): Promise<any> {
   })
 }
 
-export function activate(context: ExtensionContext): void {
+export async function activate(context: ExtensionContext): Promise<void> {
   const { fileIsIgnored } = ignoreFileHandler(context.subscriptions)
   const editProvider = new EditProvider(fileIsIgnored)
   const statusItem = workspace.createStatusBarItem(0)
   const config = workspace.getConfiguration('prettier')
   statusItem.text = config.get<string>('statusItemText', 'Prettier')
   let priority = config.get<number>('formatterPriority', 1)
+  let document = await workspace.document
+  const parsedUri = Uri.parse(document.textDocument.uri)
+  const vscodeConfig: PrettierVSCodeConfig = getConfig(parsedUri)
 
-  async function checkDocuemnt(): Promise<void> {
+  async function checkDocument(): Promise<void> {
     await wait(30)
     let doc = workspace.getDocument(workspace.bufnr)
     let languageIds = enabledLanguages()
@@ -75,6 +79,11 @@ export function activate(context: ExtensionContext): void {
   function registerFormatter(): void {
     disposeHandlers()
     const { languageSelector, rangeLanguageSelector } = selectors()
+    
+    if(vscodeConfig.onlyUseLocalVersion && !hasLocalPrettierInstalled(parsedUri.fsPath)) {
+      workspace.showMessage(`Flag prettier.onlyUseLocalVersion is set, but prettier is not installed locally. No operation will be made.`, 'warning') 
+      return
+    }
 
     rangeFormatterHandler = languages.registerDocumentRangeFormatProvider(
       rangeLanguageSelector,
@@ -89,12 +98,12 @@ export function activate(context: ExtensionContext): void {
     )
   }
   registerFormatter()
-  checkDocuemnt().catch(_e => {
+  checkDocument().catch(_e => {
     // noop
   })
 
   events.on('BufEnter', async () => {
-    await checkDocuemnt()
+    await checkDocument()
   }, null, context.subscriptions)
 
   context.subscriptions.push(
@@ -103,11 +112,14 @@ export function activate(context: ExtensionContext): void {
   )
   context.subscriptions.push(
     commands.registerCommand('prettier.formatFile', async () => {
-      let document = await workspace.document
       let languageId = document.filetype
       let languages = allLanguages()
       if (languages.indexOf(languageId) == -1) {
         workspace.showMessage(`${document.filetype} not supported by prettier`, 'error')
+        return
+      }
+      if(vscodeConfig.onlyUseLocalVersion && !hasLocalPrettierInstalled(parsedUri.fsPath)) {
+        workspace.showMessage(`Flag prettier.onlyUseLocalVersion is set, but prettier is not installed locally. No operation will be made.`, 'warning') 
         return
       }
       let edits = await format(document.content, document.textDocument, {}).then(code => [

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -1,29 +1,39 @@
 import { addToOutput } from './errorHandler'
-import path from 'path'
 import resolveFrom from 'resolve-from'
 
 declare var __webpack_require__: any
 declare var __non_webpack_require__: any
 const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require
 
+interface Options {
+  silent: boolean
+  ignoreBundled: boolean
+}
+
 /**
- * Require package explicitely installed relative to given path.
- * Fallback to bundled one if no pacakge was found bottom up.
+ * Require package explicitly installed relative to given path.
+ * Fallback to bundled one if no package was found bottom up.
  * @param {string} fspath file system path starting point to resolve package
  * @param {string} pkgName package's name to require
  * @returns module
  */
-function requireLocalPkg(fspath: string, pkgName: string): any {
+function requireLocalPkg(
+  fspath: string,
+  pkgName: string,
+  options: Options = { silent: false, ignoreBundled: false }
+): any {
   let modulePath = resolveFrom.silent(fspath, pkgName)
 
   if (modulePath !== void 0) {
     try {
       return requireFunc(modulePath)
     } catch (e) {
-      addToOutput(`Failed to load ${pkgName} from ${modulePath}. Using bundled`, 'Error')
+      if(!options.silent) {
+        addToOutput(`Failed to load ${pkgName} from ${modulePath}.${options.ignoreBundled ? `` : ` Using bundled`}`, 'Error')
+      }
     }
   }
 
-  return requireFunc(pkgName)
+  return options.ignoreBundled ? null : requireFunc(pkgName)
 }
 export { requireLocalPkg }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -87,6 +87,10 @@ interface ExtensionConfig {
    * Array of language IDs to ignore
    */
   disableLanguages: string[]
+  /**
+   * Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier
+   */
+  onlyUseLocalVersion: boolean
 }
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,10 @@ module.exports = {
     'prettier': 'commonjs prettier',
     'prettier-eslint': 'commonjs prettier-eslint',
     'prettier-stylelint': 'commonjs prettier-stylelint',
-    'prettier-tslint': 'commonjs prettier-tslint'
+    'prettier-tslint': 'commonjs prettier-tslint',
+    'spdx-license-ids/deprecated': 'commonjs spdx-license-ids/deprecated',
+    'spdx-license-ids': 'commonjs spdx-license-ids',
+    'spdx-exceptions': 'commonjs spdx-exceptions'
   },
   module: {
     rules: [{

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,18 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
   integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
 
+"@types/normalize-package-data@*", "@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/read-pkg-up@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/read-pkg-up/-/read-pkg-up-3.0.1.tgz#05911057c3be1aade38bfecbb9a8554dbd0582be"
+  integrity sha512-rMD+eDN93H/f6UGe6HJjJ08L+Vro+LN0bfCdYxsSb3Np13s75Lv+E/XBgw14kjz83Pfi82fb5z3/jtw1S3DvgA==
+  dependencies:
+    "@types/normalize-package-data" "*"
+
 "@types/semver@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
@@ -767,9 +779,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805:
-  version "1.0.30000974"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
-  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
+  version "1.0.30000978"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000978.tgz#1e3346c27fc46bce9ac1ccd77863153a263dde56"
+  integrity sha512-H6gK6kxUzG6oAwg/Jal279z8pHw0BzrpZfwo/CA9FFm/vA0l8IhDfkZtepyJNE2Y4V6Dp3P3ubz6czby1/Mgsw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -1377,9 +1389,9 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     stream-shift "^1.0.0"
 
 electron-to-chromium@^1.3.30:
-  version "1.3.164"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz#8680b875577882c1572c42218d53fa9ba5f71d5d"
-  integrity sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg==
+  version "1.3.176"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.176.tgz#df54c54386e0f205dc6d1f5582d9e8b0cd30532b"
+  integrity sha512-hsQ/BH6x2iCvJ7WOIbNTAlsT39vsVGIVoJJ9i6ZkGXUE2LdzWsNv0xJI2uZ5/Hkqv1oTTLxAYjbtGKVJzqYbjA==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -1803,6 +1815,14 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 findup-sync@^2.0.0:
   version "2.0.0"
@@ -2856,6 +2876,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
@@ -3371,7 +3398,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -3568,7 +3595,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
@@ -3588,6 +3615,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -3710,6 +3744,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -4131,6 +4170,15 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
+read-pkg-up@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-6.0.0.tgz#da75ce72762f2fa1f20c5a40d4dd80c77db969e3"
+  integrity sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==
+  dependencies:
+    find-up "^4.0.0"
+    read-pkg "^5.1.1"
+    type-fest "^0.5.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -4148,6 +4196,16 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+read-pkg@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.1.1.tgz#5cf234dde7a405c90c88a519ab73c467e9cb83f5"
+  integrity sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^4.0.0"
+    type-fest "^0.4.1"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
@@ -5190,6 +5248,16 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
+  integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
+
+type-fest@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
+  integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This addresses the second point of issue #12, basically implementing the option `prettier.onlyUseLocalVersion`, which totally ignores the bundled version if set to true, which by default is false. TBH, I feel like maybe we should change it to be the default true, as I don't see much sense in having the extension enabled on projects which don't use prettier, but I wanted to see what do you think first about that.