### PR TITLE
Fix workspace.document scope

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const config = workspace.getConfiguration('prettier')
   statusItem.text = config.get<string>('statusItemText', 'Prettier')
   let priority = config.get<number>('formatterPriority', 1)
-  let document = await workspace.document
 
   async function checkDocument(): Promise<void> {
     await wait(30)
@@ -105,6 +104,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   )
   context.subscriptions.push(
     commands.registerCommand('prettier.formatFile', async () => {
+      let document = await workspace.document
       let languageId = document.filetype
       let languages = allLanguages()
       if (languages.indexOf(languageId) == -1) {


### PR DESCRIPTION
The scope of `workspace.document` should not be outside format function. Otherwise, it will not be formatted correctly when opening multiple files.

For example: open a directory first, then open a file, then format it, and then an error occurs.

![image](https://user-images.githubusercontent.com/1709072/60394210-455fae00-9b53-11e9-96ad-182e006f6778.png)