### PR TITLE
add option to disable 'Formatted by prettier' message

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -165,6 +165,10 @@ Text of status item indicating current buffer can't be formatted by prettier.
 
 Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier
 
+#### prettier.disableSuccessMessage (default: false)
+
+Disable the 'Formatted by prettier' message which is echoed every time a file is successfully formatted
+
 ## Prettier resolution
 
 This extension will use prettier from your project's local dependencies. Should prettier not be installed locally with your project's dependencies, a copy will be bundled with the extension.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
           "description": "Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier",
           "scope": "resource"
         },
+        "prettier.disableSuccessMessage": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable the 'Formatted by prettier' message which is echoed every time a file is successfully formatted",
+          "scope": "resource"
+        },
         "prettier.statusItemText": {
           "type": "string",
           "default": "Prettier",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -90,7 +90,11 @@ interface ExtensionConfig {
   /**
    * Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier
    */
-  onlyUseLocalVersion: boolean
+  onlyUseLocalVersion: boolean,
+  /**
+   * Disable the 'Formatted by prettier' message which is echoed every time a file is successfully formatted
+   */
+  disableSuccessMessage: boolean
 }
 
 /**


### PR DESCRIPTION
Hi, added an option to disable that 'Formatted by prettier' message which I personally find very annoying and redundant.

It also very often hides other more useful messages that would be shown in that area...

Let me know if there is any issue with the implementation :)