### PR TITLE
Use the locally installed version of prettier to fetch langauges

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "bracketSpacing": true
+}

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -4,7 +4,7 @@ import { CancellationToken, FormattingOptions, Range, TextDocument, TextEdit } f
 import { addToOutput, safeExecution } from './errorHandler'
 import { requireLocalPkg } from './requirePkg'
 import { ParserOption, Prettier, PrettierConfig, PrettierEslintFormat, PrettierStylelint, PrettierTslintFormat, PrettierVSCodeConfig } from './types.d'
-import { getConfig, getParsersFromLanguageId } from './utils'
+import { allLanguages, getConfig, getParsersFromLanguageId } from './utils'
 
 /**
  * HOLD style parsers (for stylelint integration)
@@ -86,6 +86,12 @@ export async function format(
   const resolvedPrettier = await requireLocalPkg(path.dirname(fileName), 'prettier', { silent: true, ignoreBundled: localOnly }) as Prettier
   if (!resolvedPrettier) {
     addToOutput(`Prettier module not found, prettier.onlyUseLocalVersion: ${vscodeConfig.onlyUseLocalVersion}`, 'Error')
+  }
+
+  let supportedLanguages = allLanguages(resolvedPrettier)
+  if (supportedLanguages.indexOf(languageId) == -1) {
+    workspace.showMessage(`${languageId} not supported by prettier`, 'error')
+    return
   }
 
   const dynamicParsers = getParsersFromLanguageId(

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -1,17 +1,44 @@
-import { Uri, workspace, DocumentFormattingEditProvider, DocumentRangeFormattingEditProvider } from 'coc.nvim'
+import {
+  Uri,
+  workspace,
+  DocumentFormattingEditProvider,
+  DocumentRangeFormattingEditProvider,
+} from 'coc.nvim'
 import path from 'path'
-import { CancellationToken, FormattingOptions, Range, TextDocument, TextEdit } from 'vscode-languageserver-protocol'
+import {
+  CancellationToken,
+  FormattingOptions,
+  Range,
+  TextDocument,
+  TextEdit,
+} from 'vscode-languageserver-protocol'
 import { addToOutput, safeExecution } from './errorHandler'
 import { requireLocalPkg } from './requirePkg'
-import { ParserOption, Prettier, PrettierConfig, PrettierEslintFormat, PrettierStylelint, PrettierTslintFormat, PrettierVSCodeConfig } from './types.d'
-import { allLanguages, getConfig, getParsersFromLanguageId } from './utils'
+import {
+  ParserOption,
+  Prettier,
+  PrettierConfig,
+  PrettierEslintFormat,
+  PrettierStylelint,
+  PrettierTslintFormat,
+  PrettierVSCodeConfig,
+} from './types.d'
+import {
+  allLanguages,
+  getConfig,
+  getParsersFromLanguageId,
+  getPrettierInstance,
+} from './utils'
 
 /**
  * HOLD style parsers (for stylelint integration)
  */
 const STYLE_PARSERS: ParserOption[] = ['postcss', 'css', 'less', 'scss']
 
-interface ResolveConfigResult { config: PrettierConfig | null; error?: Error }
+interface ResolveConfigResult {
+  config: PrettierConfig | null
+  error?: Error
+}
 
 /**
  * Resolves the prettierconfig for the given file.
@@ -20,10 +47,18 @@ interface ResolveConfigResult { config: PrettierConfig | null; error?: Error }
  */
 async function resolveConfig(
   filePath: string,
-  options: { editorconfig?: boolean, onlyUseLocalVersion: boolean, requireConfig: boolean }
+  options: {
+    editorconfig?: boolean
+    onlyUseLocalVersion: boolean
+    requireConfig: boolean
+  }
 ): Promise<ResolveConfigResult> {
   try {
-    const localPrettier = await requireLocalPkg(path.dirname(filePath), 'prettier', { silent: true, ignoreBundled: true }) as Prettier
+    const localPrettier = (await requireLocalPkg(
+      path.dirname(filePath),
+      'prettier',
+      { silent: true, ignoreBundled: true }
+    )) as Prettier
     let prettierInstance = localPrettier
     if (!prettierInstance && !options.onlyUseLocalVersion) {
       prettierInstance = require('prettier')
@@ -60,10 +95,10 @@ function mergeConfig(
 ): any {
   return hasPrettierConfig
     ? Object.assign(
-      { parser: vscodeConfig.parser }, // always merge our inferred parser in
-      prettierConfig,
-      additionalConfig
-    )
+        { parser: vscodeConfig.parser }, // always merge our inferred parser in
+        prettierConfig,
+        additionalConfig
+      )
     : Object.assign(vscodeConfig, prettierConfig, additionalConfig)
 }
 /**
@@ -83,9 +118,12 @@ export async function format(
   const vscodeConfig: PrettierVSCodeConfig = getConfig(u)
 
   const localOnly = vscodeConfig.onlyUseLocalVersion
-  const resolvedPrettier = await requireLocalPkg(path.dirname(fileName), 'prettier', { silent: true, ignoreBundled: localOnly }) as Prettier
+  const resolvedPrettier = await getPrettierInstance()
   if (!resolvedPrettier) {
-    addToOutput(`Prettier module not found, prettier.onlyUseLocalVersion: ${vscodeConfig.onlyUseLocalVersion}`, 'Error')
+    addToOutput(
+      `Prettier module not found, prettier.onlyUseLocalVersion: ${vscodeConfig.onlyUseLocalVersion}`,
+      'Error'
+    )
   }
 
   let supportedLanguages = allLanguages(resolvedPrettier)
@@ -127,7 +165,7 @@ export async function format(
   const { config: fileOptions, error } = await resolveConfig(fileName, {
     editorconfig: true,
     onlyUseLocalVersion: localOnly,
-    requireConfig: vscodeConfig.requireConfig
+    requireConfig: vscodeConfig.requireConfig,
   })
   const hasConfig = fileOptions != null
   if (!hasConfig && vscodeConfig.requireConfig) {
@@ -135,7 +173,10 @@ export async function format(
   }
 
   if (error) {
-    addToOutput(`Failed to resolve config for ${fileName}. Falling back to the default config settings.`, 'Error')
+    addToOutput(
+      `Failed to resolve config for ${fileName}. Falling back to the default config settings.`,
+      'Error'
+    )
   }
 
   const prettierOptions = mergeConfig(
@@ -179,7 +220,10 @@ export async function format(
   if (vscodeConfig.eslintIntegration && doesParserSupportEslint) {
     return safeExecution(
       () => {
-        const prettierEslint = requireLocalPkg(u.fsPath, 'prettier-eslint') as PrettierEslintFormat
+        const prettierEslint = requireLocalPkg(
+          u.fsPath,
+          'prettier-eslint'
+        ) as PrettierEslintFormat
         // setUsedModule('prettier-eslint', 'Unknown', true)
 
         return prettierEslint({
@@ -194,7 +238,10 @@ export async function format(
   }
 
   if (vscodeConfig.stylelintIntegration && STYLE_PARSERS.includes(parser)) {
-    const prettierStylelint = requireLocalPkg(u.fsPath, 'prettier-stylelint') as PrettierStylelint
+    const prettierStylelint = requireLocalPkg(
+      u.fsPath,
+      'prettier-stylelint'
+    ) as PrettierStylelint
     return safeExecution(
       prettierStylelint.format({
         text,
@@ -211,12 +258,8 @@ export async function format(
     return safeExecution(
       () => {
         const warningMessage =
-          `prettier@${
-          bundledPrettier.version
-          } doesn't support ${languageId}. ` +
-          `Falling back to bundled prettier@${
-          bundledPrettier.version
-          }.`
+          `prettier@${bundledPrettier.version} doesn't support ${languageId}. ` +
+          `Falling back to bundled prettier@${bundledPrettier.version}.`
 
         addToOutput(warningMessage, 'Warning')
 
@@ -249,9 +292,9 @@ export function fullDocumentRange(document: TextDocument): Range {
 
 class PrettierEditProvider
   implements
-  DocumentRangeFormattingEditProvider,
-  DocumentFormattingEditProvider {
-  constructor(private _fileIsIgnored: (filePath: string) => boolean) { }
+    DocumentRangeFormattingEditProvider,
+    DocumentFormattingEditProvider {
+  constructor(private _fileIsIgnored: (filePath: string) => boolean) {}
 
   public provideDocumentRangeFormattingEdits(
     document: TextDocument,
@@ -284,7 +327,7 @@ class PrettierEditProvider
 
     const code = await format(document.getText(), document, options)
     const edits = [await TextEdit.replace(fullDocumentRange(document), code)]
-    const {disableSuccessMessage} = getConfig()
+    const { disableSuccessMessage } = getConfig()
 
     if (edits && edits.length && !disableSuccessMessage) {
       workspace.showMessage('Formatted by prettier')

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import configFileListener from './configCacheHandler'
 import { setupErrorHandler } from './errorHandler'
 import ignoreFileHandler from './ignoreFileHandler'
 import EditProvider, { format, fullDocumentRange } from './PrettierEditProvider'
-import { allLanguages, rangeLanguages, enabledLanguages, getConfig, hasLocalPrettierInstalled } from './utils'
+import { rangeLanguages, enabledLanguages, getConfig, hasLocalPrettierInstalled } from './utils'
 import { PrettierVSCodeConfig } from './types'
 
 interface Selectors {
@@ -105,12 +105,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     commands.registerCommand('prettier.formatFile', async () => {
       let document = await workspace.document
-      let languageId = document.filetype
-      let languages = allLanguages()
-      if (languages.indexOf(languageId) == -1) {
-        workspace.showMessage(`${document.filetype} not supported by prettier`, 'error')
-        return
-      }
       let prettierConfig = workspace.getConfiguration('prettier', document.uri)
       let onlyUseLocalVersion = prettierConfig.get<boolean>('onlyUseLocalVersion', false)
       if (onlyUseLocalVersion && (!hasLocalPrettierInstalled(Uri.parse(document.uri).fsPath) || document.schema != 'file')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,27 @@
-import { ExtensionContext, events, workspace, languages, commands, Uri } from 'coc.nvim'
-import { Disposable, DocumentSelector, TextEdit } from 'vscode-languageserver-protocol'
+import {
+  ExtensionContext,
+  events,
+  workspace,
+  languages,
+  commands,
+  Uri,
+} from 'coc.nvim'
+import {
+  Disposable,
+  DocumentSelector,
+  TextEdit,
+} from 'vscode-languageserver-protocol'
 import configFileListener from './configCacheHandler'
 import { setupErrorHandler } from './errorHandler'
 import ignoreFileHandler from './ignoreFileHandler'
 import EditProvider, { format, fullDocumentRange } from './PrettierEditProvider'
-import { rangeLanguages, enabledLanguages, getConfig, hasLocalPrettierInstalled } from './utils'
-import { PrettierVSCodeConfig } from './types'
+import {
+  rangeLanguages,
+  enabledLanguages,
+  hasLocalPrettierInstalled,
+  getPrettierInstance,
+} from './utils'
+import { Prettier } from './types'
 
 interface Selectors {
   rangeLanguageSelector: DocumentSelector
@@ -32,13 +48,22 @@ function disposeHandlers(): void {
 /**
  * Build formatter selectors
  */
-function selectors(): Selectors {
-  let languageSelector = enabledLanguages().reduce((curr, language) => {
-    return curr.concat([{ language, scheme: 'file' }, { language, scheme: 'untitled' }])
-  }, [])
+function selectors(prettierInstance: Prettier): Selectors {
+  let languageSelector = enabledLanguages(prettierInstance).reduce(
+    (curr, language) => {
+      return curr.concat([
+        { language, scheme: 'file' },
+        { language, scheme: 'untitled' },
+      ])
+    },
+    []
+  )
 
   let rangeLanguageSelector = rangeLanguages().reduce((curr, language) => {
-    return curr.concat([{ language, scheme: 'file' }, { language, scheme: 'untitled' }])
+    return curr.concat([
+      { language, scheme: 'file' },
+      { language, scheme: 'untitled' },
+    ])
   }, [])
   return {
     languageSelector,
@@ -61,11 +86,12 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const config = workspace.getConfiguration('prettier')
   statusItem.text = config.get<string>('statusItemText', 'Prettier')
   let priority = config.get<number>('formatterPriority', 1)
+  const prettierInstance = await getPrettierInstance()
 
   async function checkDocument(): Promise<void> {
     await wait(30)
     let doc = workspace.getDocument(workspace.bufnr)
-    let languageIds = enabledLanguages()
+    let languageIds = enabledLanguages(prettierInstance)
     if (doc && languageIds.indexOf(doc.filetype) !== -1) {
       statusItem.show()
     } else {
@@ -75,7 +101,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   function registerFormatter(): void {
     disposeHandlers()
-    const { languageSelector, rangeLanguageSelector } = selectors()
+    const { languageSelector, rangeLanguageSelector } = selectors(
+      prettierInstance
+    )
 
     rangeFormatterHandler = languages.registerDocumentRangeFormatProvider(
       rangeLanguageSelector,
@@ -94,24 +122,40 @@ export async function activate(context: ExtensionContext): Promise<void> {
     // noop
   })
 
-  events.on('BufEnter', async () => {
-    await checkDocument()
-  }, null, context.subscriptions)
-
-  context.subscriptions.push(
-    setupErrorHandler(),
-    configFileListener()
+  events.on(
+    'BufEnter',
+    async () => {
+      await checkDocument()
+    },
+    null,
+    context.subscriptions
   )
+
+  context.subscriptions.push(setupErrorHandler(), configFileListener())
   context.subscriptions.push(
     commands.registerCommand('prettier.formatFile', async () => {
       let document = await workspace.document
       let prettierConfig = workspace.getConfiguration('prettier', document.uri)
-      let onlyUseLocalVersion = prettierConfig.get<boolean>('onlyUseLocalVersion', false)
-      if (onlyUseLocalVersion && (!hasLocalPrettierInstalled(Uri.parse(document.uri).fsPath) || document.schema != 'file')) {
-        workspace.showMessage(`Flag prettier.onlyUseLocalVersion is set, but prettier is not installed locally. No operation will be made.`, 'warning')
+      let onlyUseLocalVersion = prettierConfig.get<boolean>(
+        'onlyUseLocalVersion',
+        false
+      )
+      if (
+        onlyUseLocalVersion &&
+        (!hasLocalPrettierInstalled(Uri.parse(document.uri).fsPath) ||
+          document.schema != 'file')
+      ) {
+        workspace.showMessage(
+          `Flag prettier.onlyUseLocalVersion is set, but prettier is not installed locally. No operation will be made.`,
+          'warning'
+        )
         return
       }
-      let edits = await format(document.content, document.textDocument, {}).then(code => [
+      let edits = await format(
+        document.content,
+        document.textDocument,
+        {}
+      ).then(code => [
         TextEdit.replace(fullDocumentRange(document.textDocument), code),
       ])
       if (edits && edits.length) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,8 +35,8 @@ export function getParsersFromLanguageId(
   return language.parsers
 }
 
-export function allLanguages(): string[] {
-  return getSupportLanguages().reduce(
+export function allLanguages(prettierInstance: Prettier): string[] {
+  return getSupportLanguages(prettierInstance).reduce(
     (ids, language) => [...ids, ...(language.vscodeLanguageIds || [])],
     [] as string[]
   )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { workspace, Uri } from 'coc.nvim'
-import { basename } from 'path'
+import path, { basename } from 'path'
 import {
   PrettierVSCodeConfig,
   Prettier,
@@ -7,11 +7,37 @@ import {
   ParserOption,
 } from './types.d'
 import { requireLocalPkg } from './requirePkg'
-
-const bundledPrettier = require('prettier') as Prettier
+import { addToOutput } from './errorHandler'
 
 export function getConfig(uri?: Uri): PrettierVSCodeConfig {
-  return workspace.getConfiguration('prettier', uri ? uri.toString() : undefined) as any
+  return workspace.getConfiguration(
+    'prettier',
+    uri ? uri.toString() : undefined
+  ) as any
+}
+
+export async function getPrettierInstance(): Promise<Prettier> {
+  const document = await workspace.document
+  const uri = Uri.parse(document.uri)
+
+  const fileName = uri.fsPath
+  const vscodeConfig: PrettierVSCodeConfig = getConfig(uri)
+
+  const localOnly = vscodeConfig.onlyUseLocalVersion
+  const resolvedPrettier = (await requireLocalPkg(
+    path.dirname(fileName),
+    'prettier',
+    { silent: true, ignoreBundled: localOnly }
+  )) as Prettier
+
+  if (!resolvedPrettier) {
+    addToOutput(
+      `Prettier module not found, prettier.onlyUseLocalVersion: ${vscodeConfig.onlyUseLocalVersion}`,
+      'Error'
+    )
+  }
+
+  return resolvedPrettier
 }
 
 export function getParsersFromLanguageId(
@@ -19,7 +45,8 @@ export function getParsersFromLanguageId(
   prettierInstance: Prettier,
   path?: string
 ): ParserOption[] {
-  const language = getSupportLanguages(prettierInstance).find(
+  const supportedLanguages = getSupportLanguages(prettierInstance)
+  const language = supportedLanguages.find(
     lang =>
       Array.isArray(lang.vscodeLanguageIds) &&
       lang.vscodeLanguageIds.includes(languageId) &&
@@ -36,18 +63,18 @@ export function getParsersFromLanguageId(
 }
 
 export function allLanguages(prettierInstance: Prettier): string[] {
-  return getSupportLanguages(prettierInstance).reduce(
+  const supportedLanguages = getSupportLanguages(prettierInstance)
+  return supportedLanguages.reduce(
     (ids, language) => [...ids, ...(language.vscodeLanguageIds || [])],
     [] as string[]
   )
 }
 
-export function enabledLanguages(): string[] {
+export function enabledLanguages(prettierInstance: Prettier): string[] {
   const { disableLanguages } = getConfig()
-  return getSupportLanguages().reduce(
-    (ids, language) => [...ids, ...(language.vscodeLanguageIds || [])],
-    [] as string[]
-  ).filter(x => disableLanguages.indexOf(x) == -1)
+  const languages = allLanguages(prettierInstance)
+
+  return languages.filter(x => disableLanguages.indexOf(x) == -1)
 }
 
 export function rangeLanguages(): string[] {
@@ -62,15 +89,24 @@ export function rangeLanguages(): string[] {
   ].filter(x => disableLanguages.indexOf(x) == -1)
 }
 
-export function getGroup(group: string): PrettierSupportInfo['languages'] {
-  return getSupportLanguages().filter(language => language.group === group)
+export function getGroup(
+  group: string,
+  prettierInstance: Prettier
+): PrettierSupportInfo['languages'] {
+  const supportedLanguages = getSupportLanguages(prettierInstance)
+  return supportedLanguages.filter(language => language.group === group)
 }
 
-function getSupportLanguages(prettierInstance: Prettier = bundledPrettier): any {
+function getSupportLanguages(
+  prettierInstance: Prettier
+): PrettierSupportInfo['languages'] {
   return prettierInstance.getSupportInfo(prettierInstance.version).languages
 }
 
 export function hasLocalPrettierInstalled(filePath: string): boolean {
-  const localPrettier = requireLocalPkg(filePath, 'prettier', { silent: true, ignoreBundled: true })
+  const localPrettier = requireLocalPkg(filePath, 'prettier', {
+    silent: true,
+    ignoreBundled: true,
+  })
   return localPrettier != null
 }


### PR DESCRIPTION
Before this PR, the supported languages used to determine if a document can be formatted was always fetched from the bundled version. This meant that even though the local version had plugins to enable formatting ruby, it didn't work. 

This pull request fetches all language data (enabled/supported languages) from the locally installed version when `onlyUseLocalVersion` is present.

Should fix #29 