### PR TITLE
Do not use resolveConfigFile unnecessarily

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -63,10 +63,6 @@ async function resolveConfig(
     if (!prettierInstance && !options.onlyUseLocalVersion) {
       prettierInstance = require('prettier')
     }
-    const configPath = await prettierInstance.resolveConfigFile(filePath)
-    if (options.requireConfig && !configPath) {
-      return { config: null }
-    }
     const config = await prettierInstance.resolveConfig(filePath, options)
     return { config }
   } catch (error) {


### PR DESCRIPTION
resolveConfigFile was introduced in prettier@1.13.0
This usage was causing error when using older prettier.
Since resolveConfig will return null when config file was not found
(https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath-options),
Actually we do not need to use resolveConfigFile for additional check