### PR TITLE
Upgrade prettier and align defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
             "es5",
             "all"
           ],
-          "default": "none",
+          "default": "es5",
           "description": "Controls the printing of trailing commas wherever possible.\n Valid options:\n    'none' - No trailing commas\n    'es5' - Trailing commas where valid in ES5 (objects, arrays, etc)\n    'all' - Trailing commas wherever possible (function arguments)",
           "scope": "resource"
         },
@@ -152,16 +152,20 @@
             "crlf",
             "cr"
           ],
-          "default": "auto",
+          "default": "lf",
           "description": "Specify the end of line used by prettier"
         },
         "prettier.parser": {
           "type": "string",
           "enum": [
-            "babylon",
-            "flow"
+            "none",
+            "babel",
+            "babel-flow",
+            "babel-ts",
+            "flow",
+            "typescript"
           ],
-          "default": "babylon",
+          "default": "none",
           "description": "Override the parser. You shouldn't have to change this setting.",
           "scope": "resource"
         },
@@ -193,7 +197,7 @@
             "avoid",
             "always"
           ],
-          "default": "avoid",
+          "default": "always",
           "description": "Include parentheses around a sole arrow function parameter",
           "scope": "resource"
         }
@@ -235,7 +239,7 @@
     "webpack-cli": "^3.3.8"
   },
   "dependencies": {
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.2",
     "prettier-eslint": "^9.0.1",
     "prettier-stylelint": "^0.4.2",
     "prettier-tslint": "^0.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,15 +4109,15 @@ prettier-tslint@^0.4.2:
     tslint "^5.9.1"
     yargs "^11.0.0"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^1.7.0:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 pretty-format@^23.0.1:
   version "23.6.0"


### PR DESCRIPTION
Upgrade to prettier 2.0 internally and align coc-prettier's option defaults with
the new defaults of prettier 2.0. Currently, even if the local version of
prettier is 2.0, the default rules of 1.x apply.