### PR TITLE
Add 'save without formatting' command to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,8 @@ format, which should contains `Formatted by prettier`.
 
 To make prettier do the format, use command `:CocCommand prettier.formatFile`
 
+To save without formatting, use `:noa w`
+
 ## Settings
 
 ### Prettier's Settings


### PR DESCRIPTION
I was looking for a few days how to save the file without formatting, i think it should be in the documentation