### PR TITLE
fix: accurately represent arguments to `getSupportInfo`

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,6 +13,15 @@ export type ParserOption =
 
 type TrailingCommaOption = 'none' | 'es5' | 'all'
 
+type PrettierPlugin = string | object;
+
+interface PrettierSupportInfoOptions {
+  plugins?: PrettierPlugin[]
+  showUnreleased?: boolean
+  showDeprecated?: boolean
+  showInternal?: boolean
+}
+
 interface PrettierSupportInfo {
   languages: {
     name: string
@@ -120,7 +129,7 @@ export interface Prettier {
     filePath: string,
   ) => Promise<string>
   clearConfigCache: () => void
-  getSupportInfo(version?: string): PrettierSupportInfo
+  getSupportInfo(options?: PrettierSupportInfoOptions): PrettierSupportInfo
   readonly version: string
 }
 type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ export function getGroup(
 function getSupportLanguages(
   prettierInstance: Prettier
 ): PrettierSupportInfo['languages'] {
-  return prettierInstance.getSupportInfo(prettierInstance.version).languages
+  return prettierInstance.getSupportInfo().languages
 }
 
 export function hasLocalPrettierInstalled(filePath: string): boolean {


### PR DESCRIPTION
The Prettier `getSupportInfo` function does not take a string as an argument; it actually takes an object with a few configuration options in it.

https://github.com/prettier/prettier/blob/67cbab7f4849e17afa4a46a4fba30678565879a4/src/main/support.js#L15-L20

I came across this while investigating what it would take to support Handlebars files in `coc-prettier`, which would require passing the `showUnreleased` option. If you do that, the Handlebars formatting works!

Before making any kind of more-opinionated change like that, though, I figured it would make sense to first fix the difference between how `getSupportInfo` is used and how Prettier's API is actually defined.