### PR TITLE
Include unreleased languages

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,9 @@ export function getGroup(
 function getSupportLanguages(
   prettierInstance: Prettier
 ): PrettierSupportInfo['languages'] {
-  return prettierInstance.getSupportInfo().languages
+  return prettierInstance.getSupportInfo({
+    showUnreleased: true
+  }).languages
 }
 
 export function hasLocalPrettierInstalled(filePath: string): boolean {


### PR DESCRIPTION
This makes it possible to format Handlebars files on save.

Pass `showUnreleased` to `getSupportInfo`.  Users may still need to
configure their `.prettierrc.js` to properly format languages whose
support is unreleased.

For example, to support handlebars files a project can use the following
`.prettierrc.js`

```
module.exports = {
  overrides: [
    {
      files: ['**/*.hbs'],
      options: { parser: 'glimmer' },
    },
  ],
}
```
