### PR TITLE
use babel-ts for typescriptreact

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -1,6 +1,9 @@
 import {
   DocumentFormattingEditProvider,
-  DocumentRangeFormattingEditProvider, Uri, window, workspace,
+  DocumentRangeFormattingEditProvider,
+  Uri,
+  window,
+  workspace,
   CancellationToken,
   FormattingOptions,
   Range,
@@ -87,10 +90,10 @@ function mergeConfig(
 ): any {
   return hasPrettierConfig
     ? Object.assign(
-      { parser: vscodeConfig.parser }, // always merge our inferred parser in
-      prettierConfig,
-      additionalConfig
-    )
+        { parser: vscodeConfig.parser }, // always merge our inferred parser in
+        prettierConfig,
+        additionalConfig
+      )
     : Object.assign(vscodeConfig, prettierConfig, additionalConfig)
 }
 /**
@@ -145,7 +148,18 @@ export async function format(
     parser = vscodeConfig.parser
   } else {
     parser = dynamicParsers[0]
+
+    // 'typescript' parser doesn't support JSX therefore we are looking for
+    // 'babel-ts' parser
+    if (
+      parser === 'typescript' &&
+      languageId == 'typescriptreact' &&
+      dynamicParsers.includes('babel-ts')
+    ) {
+      parser = 'babel-ts'
+    }
   }
+
   const doesParserSupportEslint = [
     'javascript',
     'javascriptreact',
@@ -277,15 +291,15 @@ export function fullDocumentRange(document: TextDocument): Range {
   let doc = workspace.getDocument(document.uri)
   return {
     start: { character: 0, line: 0 },
-    end: { character: doc.getline(lastLineId).length, line: lastLineId }
+    end: { character: doc.getline(lastLineId).length, line: lastLineId },
   }
 }
 
 class PrettierEditProvider
   implements
-  DocumentRangeFormattingEditProvider,
-  DocumentFormattingEditProvider {
-  constructor(private _fileIsIgnored: (filePath: string) => boolean) { }
+    DocumentRangeFormattingEditProvider,
+    DocumentFormattingEditProvider {
+  constructor(private _fileIsIgnored: (filePath: string) => boolean) {}
 
   public provideDocumentRangeFormattingEdits(
     document: TextDocument,
@@ -317,10 +331,12 @@ class PrettierEditProvider
     }
 
     const code = await format(document.getText(), document, options)
-    const edits: TextEdit[] = [{
-      range: fullDocumentRange(document),
-      newText: code
-    }]
+    const edits: TextEdit[] = [
+      {
+        range: fullDocumentRange(document),
+        newText: code,
+      },
+    ]
     const { disableSuccessMessage } = getConfig()
 
     if (edits && edits.length && !disableSuccessMessage) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ export type ParserOption =
   | 'less'
   | 'scss'
   | 'typescript'
+  | 'babel-ts'
   | 'json'
   | 'json-stringify'
   | 'graphql'
@@ -13,7 +14,7 @@ export type ParserOption =
 
 type TrailingCommaOption = 'none' | 'es5' | 'all'
 
-type PrettierPlugin = string | object;
+type PrettierPlugin = string | object
 
 interface PrettierSupportInfoOptions {
   plugins?: PrettierPlugin[]
@@ -99,7 +100,7 @@ interface ExtensionConfig {
   /**
    * Only use the version of prettier installed by the client, ignoring the version bundled with coc-prettier
    */
-  onlyUseLocalVersion: boolean,
+  onlyUseLocalVersion: boolean
   /**
    * Disable the 'Formatted by prettier' message which is echoed every time a file is successfully formatted
    */
@@ -125,9 +126,7 @@ export interface Prettier {
       editorconfig?: boolean
     }
   ) => Promise<PrettierConfig>
-  resolveConfigFile: (
-    filePath: string,
-  ) => Promise<string>
+  resolveConfigFile: (filePath: string) => Promise<string>
   clearConfigCache: () => void
   getSupportInfo(options?: PrettierSupportInfoOptions): PrettierSupportInfo
   readonly version: string


### PR DESCRIPTION
The typescript parser doesn't support JSX and therefore we should use babel-ts for typescriptreact files.