### PR TITLE
Fix formatting typescriptreact (Again)

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -87,7 +87,10 @@ function mergeConfig(
 ): any {
   return hasPrettierConfig
     ? Object.assign(
-      { parser: vscodeConfig.parser }, // always merge our inferred parser in
+      {
+        parser: vscodeConfig.parser, // always merge our inferred parser in
+        filepath: vscodeConfig.filepath // always merge filepath to detect file type
+      },
       prettierConfig,
       additionalConfig
     )


### PR DESCRIPTION
The previous change was incomplete. `filepath` entry wasn't been used
when a configuration file is exist in a project.

fix #115