### PR TITLE
fix bug: formatFile/forceFormatFile comamnd would not work if onlyUseLocalVersion=true

### DIFF
--- a/src/PrettierEditService.ts
+++ b/src/PrettierEditService.ts
@@ -443,9 +443,6 @@ export default class PrettierEditService implements Disposable {
     );
     this.loggingService.logInfo("PrettierInstance:", prettierInstance);
 
-    if (vscodeConfig.onlyUseLocalVersion) {
-      return;
-    }
     if (!prettierInstance) {
       this.loggingService.logError(
         "Prettier could not be loaded. See previous logs for more information."


### PR DESCRIPTION

closes https://github.com/neoclide/coc-prettier/issues/184

For my understand, `this.moduleResolver.getPrettierInstance` is checking the value of `onlyUseLocalVersion` internally, so no need to see this value outside and just check if it was got.